### PR TITLE
Ease of use methods in custom and simple form builder

### DIFF
--- a/src/main/java/org/geysermc/cumulus/form/CustomForm.java
+++ b/src/main/java/org/geysermc/cumulus/form/CustomForm.java
@@ -90,6 +90,9 @@ public interface CustomForm extends Form {
    */
   interface Builder extends FormBuilder<Builder, CustomForm, CustomFormResponse> {
     @This
+    Builder icon(@NonNull FormImage image);
+
+    @This
     Builder icon(FormImage.@NonNull Type type, @NonNull String data);
 
     @This

--- a/src/main/java/org/geysermc/cumulus/form/SimpleForm.java
+++ b/src/main/java/org/geysermc/cumulus/form/SimpleForm.java
@@ -95,6 +95,15 @@ public interface SimpleForm extends Form {
     Builder content(@NonNull String content);
 
     /**
+     * Adds a button directly to the form.
+     *
+     * @param button the button to add
+     * @return the form builder
+     */
+    @This
+    Builder button(@NonNull ButtonComponent button);
+
+    /**
      * Adds a button with image to the Form.
      *
      * @param text text of the button
@@ -123,6 +132,17 @@ public interface SimpleForm extends Form {
      */
     @This
     Builder button(@NonNull String text);
+
+    /**
+     * Adds a button directly to the Form, but only when shouldAdd is true.
+     *
+     * @param button    the button to add
+     * @param shouldAdd if the button should be added
+     * @return the form builder
+     * @since 1.1
+     */
+    @This
+    Builder optionalButton(@NonNull ButtonComponent button, boolean shouldAdd);
 
     /**
      * Adds a button with image to the Form, but only when shouldAdd is true.

--- a/src/main/java/org/geysermc/cumulus/form/SimpleForm.java
+++ b/src/main/java/org/geysermc/cumulus/form/SimpleForm.java
@@ -134,17 +134,6 @@ public interface SimpleForm extends Form {
     Builder button(@NonNull String text);
 
     /**
-     * Adds a button directly to the Form, but only when shouldAdd is true.
-     *
-     * @param button    the button to add
-     * @param shouldAdd if the button should be added
-     * @return the form builder
-     * @since 1.1
-     */
-    @This
-    Builder optionalButton(@NonNull ButtonComponent button, boolean shouldAdd);
-
-    /**
      * Adds a button with image to the Form, but only when shouldAdd is true.
      *
      * @param text      text of the button

--- a/src/main/java/org/geysermc/cumulus/form/impl/custom/CustomFormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/custom/CustomFormImpl.java
@@ -89,7 +89,8 @@ public final class CustomFormImpl extends FormImpl<CustomFormResponse>
 
     @Override
     public Builder icon(FormImage.@NonNull Type type, @NonNull String data) {
-      return icon(FormImage.of(type, data));
+      icon = FormImage.of(type, data);
+      return this;
     }
 
     @Override

--- a/src/main/java/org/geysermc/cumulus/form/impl/custom/CustomFormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/custom/CustomFormImpl.java
@@ -46,7 +46,6 @@ import org.geysermc.cumulus.form.CustomForm;
 import org.geysermc.cumulus.form.impl.FormImpl;
 import org.geysermc.cumulus.response.CustomFormResponse;
 import org.geysermc.cumulus.util.FormImage;
-import org.geysermc.cumulus.util.impl.FormImageImpl;
 
 public final class CustomFormImpl extends FormImpl<CustomFormResponse>
     implements CustomForm {
@@ -83,9 +82,14 @@ public final class CustomFormImpl extends FormImpl<CustomFormResponse>
     private FormImage icon;
 
     @Override
-    public Builder icon(FormImage.@NonNull Type type, @NonNull String data) {
-      icon = new FormImageImpl(type, data);
+    public Builder icon(@NonNull FormImage image) {
+      icon = Objects.requireNonNull(image, "image");
       return this;
+    }
+
+    @Override
+    public Builder icon(FormImage.@NonNull Type type, @NonNull String data) {
+      return icon(FormImage.of(type, data));
     }
 
     @Override

--- a/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
@@ -70,27 +70,42 @@ public final class SimpleFormImpl extends FormImpl<SimpleFormResponse>
     private final List<ButtonComponent> buttons = new ArrayList<>();
     private String content = "";
 
+    @Override
     public Builder content(@NonNull String content) {
       this.content = translate(Objects.requireNonNull(content, "content"));
       return this;
     }
 
+    @Override
+    public Builder button(@NonNull ButtonComponent button) {
+      buttons.add(button);
+      return this;
+    }
+
+    @Override
     public Builder button(
         @NonNull String text,
         FormImage.@NonNull Type type,
         @NonNull String data) {
-      buttons.add(ButtonComponent.of(translate(text), type, data));
-      return this;
+      return button(ButtonComponent.of(translate(text), type, data));
     }
 
+    @Override
     public Builder button(@NonNull String text, @Nullable FormImage image) {
-      buttons.add(ButtonComponent.of(translate(text), image));
-      return this;
+      return button(ButtonComponent.of(translate(text), image));
     }
 
+    @Override
     public Builder button(@NonNull String text) {
-      buttons.add(ButtonComponent.of(translate(text)));
-      return this;
+      return button(ButtonComponent.of(translate(text)));
+    }
+
+    @Override
+    public Builder optionalButton(@NonNull ButtonComponent button, boolean shouldAdd) {
+      if (shouldAdd) {
+        return button(button);
+      }
+      return addNullButton();
     }
 
     @Override

--- a/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
@@ -78,7 +78,7 @@ public final class SimpleFormImpl extends FormImpl<SimpleFormResponse>
 
     @Override
     public Builder button(@NonNull ButtonComponent button) {
-      buttons.add(button);
+      buttons.add(Objects.requireNonNull(button, "button"));
       return this;
     }
 
@@ -98,14 +98,6 @@ public final class SimpleFormImpl extends FormImpl<SimpleFormResponse>
     @Override
     public Builder button(@NonNull String text) {
       return button(ButtonComponent.of(translate(text)));
-    }
-
-    @Override
-    public Builder optionalButton(@NonNull ButtonComponent button, boolean shouldAdd) {
-      if (shouldAdd) {
-        return button(button);
-      }
-      return addNullButton();
     }
 
     @Override

--- a/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/simple/SimpleFormImpl.java
@@ -87,17 +87,20 @@ public final class SimpleFormImpl extends FormImpl<SimpleFormResponse>
         @NonNull String text,
         FormImage.@NonNull Type type,
         @NonNull String data) {
-      return button(ButtonComponent.of(translate(text), type, data));
+      buttons.add(ButtonComponent.of(translate(text), type, data));
+      return this;
     }
 
     @Override
     public Builder button(@NonNull String text, @Nullable FormImage image) {
-      return button(ButtonComponent.of(translate(text), image));
+      buttons.add(ButtonComponent.of(translate(text), image));
+      return this;
     }
 
     @Override
     public Builder button(@NonNull String text) {
-      return button(ButtonComponent.of(translate(text)));
+      buttons.add(ButtonComponent.of(translate(text)));
+      return this;
     }
 
     @Override


### PR DESCRIPTION
- Allows directly adding `ButtonComponent` to `SimpleForm.Builder` and `FormImage` to `CustomForm.Builder`
- SimpleFormImpl.Builder was also missing some `@Override` annotations 

This will allow for cleaner code when those objects have already been created from deserialization. Feel free to edit anything