### PR TITLE
 Allow icon to be null in deprecated CustomForm#of from 1.0

### DIFF
--- a/src/main/java/org/geysermc/cumulus/CustomForm.java
+++ b/src/main/java/org/geysermc/cumulus/CustomForm.java
@@ -46,7 +46,11 @@ public interface CustomForm extends Form<org.geysermc.cumulus.form.CustomForm> {
   }
 
   static CustomForm of(String title, FormImage icon, List<Component> content) {
-    Builder builder = CustomForm.builder().title(title).icon(icon.type(), icon.data());
+    Builder builder = CustomForm.builder().title(title);
+
+    if (icon != null) {
+      builder.icon(icon.type(), icon.data());
+    }
 
     for (Component component : content) {
       builder.component(component);


### PR DESCRIPTION
In 1.0, icon was allowed to be null in `CustomForm#of`. The new deprecated implementation broke that.

https://github.com/GeyserMC/Cumulus/blob/old/1.0/src/main/java/org/geysermc/cumulus/CustomForm.java#L68