### PR TITLE
Annotate rawResponseHandlers as receiving possibly null data

### DIFF
--- a/src/main/java/org/geysermc/cumulus/Forms.java
+++ b/src/main/java/org/geysermc/cumulus/Forms.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.function.BiConsumer;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.cumulus.component.Component;
 import org.geysermc.cumulus.component.impl.DropdownComponentImpl;
 import org.geysermc.cumulus.component.impl.InputComponentImpl;
@@ -56,7 +57,7 @@ public final class Forms {
   @NonNull
   public static <T extends Form> T fromJson(
       String json, FormType type,
-      BiConsumer<T, String> responseHandler) {
+      BiConsumer<T, @Nullable String> responseHandler) {
 
     return FormDefinitions.instance()
         .<FormCodec<T, FormResponse>>codecFor(type)

--- a/src/main/java/org/geysermc/cumulus/form/impl/FormImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/impl/FormImpl.java
@@ -43,7 +43,7 @@ import org.geysermc.cumulus.response.result.ValidFormResponseResult;
 
 public abstract class FormImpl<R extends FormResponse> implements Form {
   protected Consumer<FormResponseResult<R>> responseHandler;
-  protected Consumer<String> rawResponseConsumer;
+  protected Consumer<@Nullable String> rawResponseConsumer;
 
   private final String title;
 
@@ -59,7 +59,7 @@ public abstract class FormImpl<R extends FormResponse> implements Form {
     return false;
   }
 
-  public void rawResponseConsumer(Consumer<String> rawResponseConsumer) {
+  public void rawResponseConsumer(Consumer<@Nullable String> rawResponseConsumer) {
     this.rawResponseConsumer = rawResponseConsumer;
   }
 

--- a/src/main/java/org/geysermc/cumulus/form/util/FormCodec.java
+++ b/src/main/java/org/geysermc/cumulus/form/util/FormCodec.java
@@ -43,7 +43,7 @@ public interface FormCodec<F extends Form, R extends FormResponse>
    * @param rawResponseConsumer
    * @return
    */
-  F fromJson(@NonNull String json, @Nullable BiConsumer<F, String> rawResponseConsumer);
+  F fromJson(@NonNull String json, @Nullable BiConsumer<F, @Nullable String> rawResponseConsumer);
 
   /**
    * Serializes the form to data that can be used by the Bedrock client to display the form.

--- a/src/main/java/org/geysermc/cumulus/form/util/impl/FormCodecImpl.java
+++ b/src/main/java/org/geysermc/cumulus/form/util/impl/FormCodecImpl.java
@@ -71,14 +71,14 @@ public abstract class FormCodecImpl<F extends Form, R extends FormResponse>
   @Override
   public final F fromJson(
       @NonNull String json,
-      @Nullable BiConsumer<F, String> rawResponseConsumer) {
+      @Nullable BiConsumer<F, @Nullable String> rawResponseConsumer) {
     F form = gson.fromJson(json, typeClass);
     setRawResponseConsumer(form, rawResponseConsumer);
     return form;
   }
 
   @SuppressWarnings("unchecked")
-  protected void setRawResponseConsumer(F form, BiConsumer<F, String> rawResponseConsumer) {
+  protected void setRawResponseConsumer(F form, BiConsumer<F, @Nullable String> rawResponseConsumer) {
     ((FormImpl<R>) form)
         .rawResponseConsumer(response -> rawResponseConsumer.accept(form, response));
   }


### PR DESCRIPTION
The `rawResponseConsumer` was always allowed to be called with null data [e.g.](https://github.com/Konicai/Cumulus/blob/nullable-rawResponseHandler/src/main/java/org/geysermc/cumulus/form/impl/FormImpl.java#L54)

so this is just for API clarity really